### PR TITLE
Add/redpanda console

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   grafana:
     user: root
-    container_name: 'hamedkarbasi93-kafka-datasource'
+    container_name: 'grafana'
 
     build:
       context: ./.config
@@ -53,3 +53,41 @@ services:
       KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
     volumes:
       - ./data/kafka:/var/lib/kafka/data
+
+  # Redpanda Console to have a UI for Kafka topics and messages
+  console:
+    container_name: redpanda-console
+    image: docker.redpanda.com/redpandadata/console:v2.8.5
+    entrypoint: /bin/sh
+    command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml && echo "$$CONSOLE_ROLEBINDINGS_CONFIG_FILE" > /tmp/role-bindings.yml && /app/console'
+    volumes:
+      - ./config:/tmp/config/
+    environment:
+      CONFIG_FILEPATH: ${CONFIG_FILEPATH:-/tmp/config.yml}
+      CONSOLE_CONFIG_FILE: |
+        # Configure a connection to the Redpanda cluster
+        # See https://docs.redpanda.com/current/console/config/connect-to-redpanda/
+        kafka:
+          brokers: ["kafka:29092"]
+          # sasl:
+          #   enabled: true
+          #   username: superuser
+          #   password: secretpassword
+          #   mechanism: SCRAM-SHA-256
+        console:
+          # Configures Redpanda Console to fetch topic documentation from GitHub and display it in the UI.
+          # See https://docs.redpanda.com/current/console/config/topic-documentation/
+          topicDocumentation:
+            enabled: true
+            git:
+              enabled: true
+              repository:
+                url: https://github.com/redpanda-data/docs
+                branch: main
+                baseDirectory: tests/docker-compose
+        login:
+          enabled: false
+    ports:
+      - 8080:8080
+    depends_on:
+      - kafka

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,6 +58,7 @@ services:
   console:
     container_name: redpanda-console
     image: docker.redpanda.com/redpandadata/console:v2.8.5
+    restart: always
     entrypoint: /bin/sh
     command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml && echo "$$CONSOLE_ROLEBINDINGS_CONFIG_FILE" > /tmp/role-bindings.yml && /app/console'
     volumes:
@@ -65,26 +66,8 @@ services:
     environment:
       CONFIG_FILEPATH: ${CONFIG_FILEPATH:-/tmp/config.yml}
       CONSOLE_CONFIG_FILE: |
-        # Configure a connection to the Redpanda cluster
-        # See https://docs.redpanda.com/current/console/config/connect-to-redpanda/
         kafka:
           brokers: ["kafka:29092"]
-          # sasl:
-          #   enabled: true
-          #   username: superuser
-          #   password: secretpassword
-          #   mechanism: SCRAM-SHA-256
-        console:
-          # Configures Redpanda Console to fetch topic documentation from GitHub and display it in the UI.
-          # See https://docs.redpanda.com/current/console/config/topic-documentation/
-          topicDocumentation:
-            enabled: true
-            git:
-              enabled: true
-              repository:
-                url: https://github.com/redpanda-data/docs
-                branch: main
-                baseDirectory: tests/docker-compose
         login:
           enabled: false
     ports:

--- a/example/python/README.md
+++ b/example/python/README.md
@@ -2,7 +2,7 @@
 In this folder, there is a simple python sample producer that generates json values in topic `test` in Kafka every 0.5s.
 
 ## Requirements
-confluent-kafka==1.9.0
+confluent-kafka==2.9.0
 
 ## Usage
 ```bash


### PR DESCRIPTION
This PR:

- Changes the name of the Grafana's container to make it more clear
- Adds the redpanda-console as an UI
- Bumps the confluent python package version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new management console that provides enhanced functionality for managing Kafka topics and messages. This new interface integrates seamlessly with current services, offering users a simplified experience for monitoring and configuration tasks.

- **Chores**
  - Streamlined service naming conventions for better clarity and consistency.
  - Upgraded the `confluent-kafka` dependency to version `2.9.0` to ensure improved performance and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->