### PR TITLE
Fix switch component

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -106,7 +106,7 @@ export class QueryEditor extends PureComponent<Props> {
               Enable streaming <small>(v8+)</small>
             </InlineFormLabel>
             <div className="add-data-source-item-badge">
-              <Switch css checked={withStreaming || false} onChange={this.onWithStreamingChange} />
+              <Switch css value={withStreaming} onChange={this.onWithStreamingChange} />
             </div>
           </InlineFieldRow>
         </div>


### PR DESCRIPTION
Fix of wrong property usage. It should be `value` instead of `checked`. Fixes the behaviour of the "Enable streaming" component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the toggle control for the "Enable streaming" option in the query editor for improved consistency. No visible changes to user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->