### PR TITLE
add backend tests

### DIFF
--- a/pkg/kafka_client/client_test.go
+++ b/pkg/kafka_client/client_test.go
@@ -1,0 +1,52 @@
+package kafka_client
+
+import (
+	"testing"
+)
+
+func TestNewKafkaClient_Defaults(t *testing.T) {
+	options := Options{BootstrapServers: "localhost:9092"}
+	client := NewKafkaClient(options)
+	if client.BootstrapServers != "localhost:9092" {
+		t.Errorf("Expected BootstrapServers to be 'localhost:9092', got %s", client.BootstrapServers)
+	}
+	if client.HealthcheckTimeout <= 0 {
+		t.Error("Expected HealthcheckTimeout to be set to default if not provided")
+	}
+}
+
+func TestKafkaClient_NewConnection_NoSASL(t *testing.T) {
+	client := NewKafkaClient(Options{BootstrapServers: "localhost:9092"})
+	err := client.NewConnection()
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if client.Dialer == nil {
+		t.Error("Expected Dialer to be initialized")
+	}
+	if client.Conn == nil {
+		t.Error("Expected Conn to be initialized")
+	}
+}
+
+func TestKafkaClient_Dispose(t *testing.T) {
+	client := NewKafkaClient(Options{BootstrapServers: "localhost:9092"})
+	client.Dispose() // Should not panic
+}
+
+func TestGetSASLMechanism_Unsupported(t *testing.T) {
+	client := NewKafkaClient(Options{SaslMechanisms: "UNSUPPORTED"})
+	_, err := getSASLMechanism(&client)
+	if err == nil {
+		t.Error("Expected error for unsupported SASL mechanism")
+	}
+}
+
+func TestGetKafkaLogger(t *testing.T) {
+	logger, errorLogger := getKafkaLogger("debug")
+	logger("test debug")
+	errorLogger("test error")
+	logger, errorLogger = getKafkaLogger("error")
+	logger("should not print")
+	errorLogger("should print error")
+}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -2,6 +2,7 @@ package plugin_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -26,5 +27,41 @@ func TestQueryData(t *testing.T) {
 
 	if len(resp.Responses) != 1 {
 		t.Fatal("QueryData must return a response")
+	}
+}
+
+func TestCheckHealth_OK(t *testing.T) {
+	ds := plugin.KafkaDatasource{}
+	result, err := ds.CheckHealth(context.Background(), &backend.CheckHealthRequest{
+		PluginContext: backend.PluginContext{
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+		},
+	})
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if result.Status != backend.HealthStatusOk && result.Status != backend.HealthStatusError {
+		t.Errorf("Unexpected health status: %v", result.Status)
+	}
+}
+
+func TestQuery_UnmarshalError(t *testing.T) {
+	ds := plugin.KafkaDatasource{}
+	badQuery := backend.DataQuery{JSON: []byte(`not-json`)}
+	resp, _ := ds.QueryData(context.Background(), &backend.QueryDataRequest{Queries: []backend.DataQuery{badQuery}})
+	if resp == nil {
+		t.Fatal("Expected a response, got nil")
+	}
+}
+
+func TestSubscribeStream_EmptyTopic(t *testing.T) {
+	ds := plugin.KafkaDatasource{}
+	data, _ := json.Marshal(map[string]interface{}{})
+	resp, err := ds.SubscribeStream(context.Background(), &backend.SubscribeStreamRequest{Data: data})
+	if err == nil {
+		t.Error("Expected error for empty topic")
+	}
+	if resp.Status != backend.SubscribeStreamStatusPermissionDenied {
+		t.Errorf("Expected permission denied, got %v", resp.Status)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for Kafka client, including initialization, connection handling, SASL mechanism validation, and logging setup.
  * Introduced new tests for the KafkaDatasource plugin covering health checks, query error handling, and stream subscription error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->