### PR TITLE
fix the mutation issue in the config editor and query editor

### DIFF
--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -3,7 +3,7 @@ import { InlineField, Input, Divider, SecretInput, Checkbox, SecretTextArea, Sel
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { ConfigSection, DataSourceDescription } from '@grafana/plugin-ui';
 import { KafkaDataSourceOptions, defaultDataSourceOptions, KafkaSecureJsonData } from './types';
-import { defaults, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 
 interface Props extends DataSourcePluginOptionsEditorProps<KafkaDataSourceOptions> {}
 
@@ -27,7 +27,7 @@ export const ConfigEditor = (props: Props) => {
 
   // Ensure default values are set once
   useEffect(() => {
-    const jsonData = defaults(options.jsonData, defaultDataSourceOptions);
+    const jsonData = { ...defaultDataSourceOptions, ...options.jsonData };
     if (!isEqual(options.jsonData, jsonData)) {
       onOptionsChange({ ...options, jsonData });
     }
@@ -126,7 +126,7 @@ export const ConfigEditor = (props: Props) => {
     onOptionsChange({ ...options, jsonData: { ...options.jsonData, timeout: validated } });
   };
 
-  const jsonData = defaults(options.jsonData, defaultDataSourceOptions);
+  const jsonData = { ...defaultDataSourceOptions, ...options.jsonData };
   const secureJsonData = (options.secureJsonData || {}) as KafkaSecureJsonData;
   const { secureJsonFields } = options;
 

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,4 +1,4 @@
-import { defaults, debounce, type DebouncedFunc } from 'lodash';
+import { debounce, type DebouncedFunc } from 'lodash';
 import React, { ChangeEvent, PureComponent } from 'react';
 import { InlineField, InlineFieldRow, Input, Select, Button, Spinner, Alert, InlineLabel } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
@@ -109,7 +109,8 @@ export class QueryEditor extends PureComponent<Props, State> {
 
   getPartitionOptions = (): Array<{ label: string; value: number | 'all' }> => {
     const options = [...partitionOptions];
-    const { partition } = defaults(this.props.query, defaultQuery);
+    const query = { ...defaultQuery, ...this.props.query };
+    const { partition } = query;
     const present = new Set<number>();
     (this.state.availablePartitions || []).forEach((p) => {
       options.push({ label: `Partition ${p}`, value: p });
@@ -158,7 +159,8 @@ export class QueryEditor extends PureComponent<Props, State> {
   };
 
   commitTopicIfChanged = () => {
-    const { topicName } = defaults(this.props.query, defaultQuery);
+    const query = { ...defaultQuery, ...this.props.query };
+    const { topicName } = query;
     if (topicName && topicName !== this.lastCommittedTopic) {
       this.lastCommittedTopic = topicName;
       this.props.onRunQuery();
@@ -227,7 +229,7 @@ export class QueryEditor extends PureComponent<Props, State> {
   };
 
   render() {
-    const query = defaults(this.props.query, defaultQuery);
+    const query = { ...defaultQuery, ...this.props.query };
     const { topicName, partition, autoOffsetReset, timestampMode, lastN } = query;
 
     return (

--- a/src/__tests__/ConfigEditor.test.tsx
+++ b/src/__tests__/ConfigEditor.test.tsx
@@ -139,6 +139,12 @@ beforeEach(() => {
 });
 
 describe('ConfigEditor', () => {
+  it('does not mutate frozen props', () => {
+    const frozenOptions = Object.freeze(createMockOptions());
+    expect(() => {
+      render(<ConfigEditor options={frozenOptions} onOptionsChange={mockOnOptionsChange} />);
+    }).not.toThrow();
+  });
   it('renders data source description', () => {
     renderConfigEditor();
     expect(screen.getByTestId('datasource-description')).toBeInTheDocument();

--- a/src/__tests__/QueryEditor.test.tsx
+++ b/src/__tests__/QueryEditor.test.tsx
@@ -77,6 +77,27 @@ const renderEditor = (query?: Partial<KafkaQuery>) =>
   );
 
 describe('QueryEditor', () => {
+  it('does not mutate frozen props', () => {
+    const frozenQuery: KafkaQuery = Object.freeze({
+      refId: 'A',
+      topicName: '',
+      partition: 'all',
+      autoOffsetReset: AutoOffsetReset.LATEST,
+      timestampMode: TimestampMode.Message,
+      lastN: 100,
+    });
+    expect(() => {
+      render(
+        <QueryEditor
+          datasource={mockDs}
+          onChange={onChange}
+          onRunQuery={onRunQuery}
+          query={frozenQuery}
+          app={'explore' as any}
+        />
+      );
+    }).not.toThrow();
+  });
   it('disables browser autocomplete on topic input and shows suggestions panel', async () => {
     renderEditor({ topicName: '' });
     const input = screen.getByPlaceholderText('Enter topic name') as HTMLInputElement;

--- a/src/__tests__/datasource.test.ts
+++ b/src/__tests__/datasource.test.ts
@@ -37,6 +37,21 @@ const mockInstanceSettings = {
 };
 
 describe('DataSource', () => {
+  it('does not mutate frozen query props', () => {
+    const frozenQuery = Object.freeze({
+      topicName: 'test-topic',
+      partition: 'all',
+      autoOffsetReset: AutoOffsetReset.LATEST,
+      timestampMode: TimestampMode.Message,
+      lastN: 100,
+      refId: 'A',
+    });
+    ds = new DataSource(mockInstanceSettings as any);
+    expect(() => {
+      ds.filterQuery(frozenQuery as KafkaQuery);
+      ds.applyTemplateVariables(frozenQuery as KafkaQuery, {});
+    }).not.toThrow();
+  });
   let ds: DataSource;
 
   beforeEach(() => {


### PR DESCRIPTION
Closes #89 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched default-value handling in configuration and query editors to non-mutating merges, preventing side effects and improving stability for partitions, topics, offsets, and related settings.
* **Tests**
  * Added tests ensuring editors and datasource methods do not mutate frozen input props, guarding against accidental prop mutation and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->