### PR TITLE
Feat: add SASL/OAUTHBEARER (KIP-255) authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - **Avro support:** Integrates with Schema Registry for Avro messages.
 - **Plaintext support:** Reads raw Kafka payload bytes without schema decoding.
 - **Line Protocol support:** Parses InfluxDB Line Protocol messages into a single long-format Grafana frame per message, with tags carried as columns.
-- **Secure:** SASL authentication & SSL/TLS encryption.
+- **Secure:** SASL authentication (PLAIN, SCRAM, OAUTHBEARER/OIDC) & SSL/TLS encryption.
 - **Easy setup:** Install and configure in minutes.
 
 ## How It Works
@@ -37,7 +37,7 @@ This plugin connects your Grafana instance directly to Kafka brokers, allowing y
 ## Features
 
 - Real-time monitoring of Kafka topics
-- Kafka authentication (SASL) & encryption (SSL/TLS)
+- Kafka authentication (SASL: PLAIN, SCRAM, OAUTHBEARER/OIDC client credentials) & encryption (SSL/TLS)
 - Query all or specific partitions
 - Autocomplete for topic names
 - Flexible offset options (latest, last N, earliest)
@@ -75,11 +75,11 @@ You can automatically configure the Kafka datasource using Grafana's provisionin
 
 1. Add a new data source in Grafana and select "Kafka Datasource".
 2. Configure connection settings:
-    - **Broker address** (e.g. `localhost:9094` or `kafka:9092`)
-    - **Private Data Source Connect (PDC)** (optional; requires PDC to be configured in Grafana)
-    - **Authentication** (SASL, SSL/TLS, optional)
-    - **Avro Schema Registry** (if using Avro format)
-    - **Timeout settings** (default: two seconds)
+   - **Broker address** (e.g. `localhost:9094` or `kafka:9092`)
+   - **Private Data Source Connect (PDC)** (optional; requires PDC to be configured in Grafana)
+   - **Authentication** (SASL — PLAIN, SCRAM, or OAUTHBEARER/OIDC client credentials — SSL/TLS, optional)
+   - **Avro Schema Registry** (if using Avro format)
+   - **Timeout settings** (default: two seconds)
 
 <a href="https://raw.githubusercontent.com/hoptical/grafana-kafka-datasource/ba3d10342aca7512c5679fcd7761e5b394094598/src/img/config-basic.png"><img src="https://raw.githubusercontent.com/hoptical/grafana-kafka-datasource/ba3d10342aca7512c5679fcd7761e5b394094598/src/img/config-basic.png" alt="Kafka basic datasource configuration" width="800"></a>
 
@@ -258,7 +258,7 @@ The Avro and Protobuf schema caches remain bounded with a hardcoded default size
 ## FAQ & Troubleshooting
 
 - **Can I use this with any Kafka broker?** Yes, supports Apache Kafka v0.11+ and compatible brokers.
-- **Does it support secure connections?** Yes, SASL and SSL/TLS are supported.
+- **Does it support secure connections?** Yes, SASL (PLAIN, SCRAM-SHA-256/512, OAUTHBEARER/OIDC client credentials) and SSL/TLS are supported. See [OAuth 2.0 Authentication](https://github.com/hoptical/grafana-kafka-datasource/blob/main/docs/OAUTH2_AUTH.md) for OAUTHBEARER setup.
 - **What JSON formats are supported?** Flat, nested, arrays, mixed types.
 - **What is Plaintext format?** It bypasses schema decoding and renders raw payload bytes in a single `message` field.
 - **What is Line Protocol format?** It parses [InfluxDB Line Protocol](https://docs.influxdata.com/influxdb/v2/reference/syntax/line-protocol/) messages — `measurement,tag=val field=val timestamp`. Each Kafka message produces a single Grafana frame in **long format**, one row per LP field, with a fixed streaming-friendly schema: `Time | _measurement | _field | value | value_str | <one column per tag key> | offset`. This shape works correctly with Grafana Live streaming (consistent schema per channel), and you can pivot it into Influx-style per-series frames with Grafana's **Transform → Partition by values** on `_measurement` + `_field` for dashboards that were built around the InfluxDB datasource. The **Timestamp Precision** dropdown decides how inline timestamps are interpreted; `Auto-detect` picks ns/µs/ms/s from the magnitude.
@@ -268,6 +268,7 @@ The Avro and Protobuf schema caches remain bounded with a hardcoded default size
 ## Documentation & Links
 
 - [Sample Producers](https://github.com/hoptical/grafana-kafka-datasource/blob/main/example/README.md)
+- [OAuth 2.0 Authentication](https://github.com/hoptical/grafana-kafka-datasource/blob/main/docs/OAUTH2_AUTH.md)
 - [Performance Optimizations](https://github.com/hoptical/grafana-kafka-datasource/blob/main/docs/PERFORMANCE_OPTIMIZATIONS.md)
 - [Changelog](https://github.com/hoptical/grafana-kafka-datasource/blob/main/CHANGELOG.md)
 - [Contribution Guidelines](https://github.com/hoptical/grafana-kafka-datasource/blob/main/CONTRIBUTING.md)

--- a/docs/OAUTH2_AUTH.md
+++ b/docs/OAUTH2_AUTH.md
@@ -1,0 +1,133 @@
+# SASL/OAUTHBEARER (OAuth 2.0) Authentication
+
+## Overview
+
+This datasource supports SASL/OAUTHBEARER (KIP-255), Kafka's standard mechanism for
+authenticating with a short-lived bearer token instead of a static username/password.
+It uses the OAuth 2.0 `client_credentials` grant: the plugin sends a `client_id` and
+`client_secret` (plus an optional `scope`) to your identity provider's token endpoint,
+receives a bearer token, and authenticates to Kafka with it. The token is cached and
+proactively refreshed before it expires, so no user interaction is needed after initial
+setup.
+
+This is generic OIDC client-credentials support and works with Keycloak, Okta, Azure AD,
+Ping, and any other OIDC-compliant identity provider that implements the
+`client_credentials` grant.
+
+`segmentio/kafka-go` (the Kafka client library this plugin uses) does not implement
+OAUTHBEARER itself — only PLAIN and SCRAM-SHA-256/512 — so this mechanism is implemented
+directly in `pkg/kafka_client/oauth_mechanism.go` against kafka-go's `sasl.Mechanism`
+interface.
+
+## Configuration
+
+### UI
+
+In the datasource's **Authentication** section:
+
+1. Set **Security Protocol** to `SASL_PLAINTEXT` or `SASL_SSL` (SASL_SSL is strongly
+   recommended, since credentials and tokens should not be sent over plaintext).
+2. Set **SASL Mechanism** to `OAUTHBEARER`.
+3. Fill in:
+   - **Token Endpoint**: your identity provider's OAuth 2.0 token URL.
+   - **Client ID**: the OAuth client identifier (not secret).
+   - **Client Secret**: the OAuth client secret (stored encrypted).
+   - **Scope** (optional): a space-delimited scope string requested from the token
+     endpoint, if your provider requires one.
+
+Selecting `OAUTHBEARER` replaces the SASL Username/Password fields used by PLAIN/SCRAM
+with these OAuth fields; only one credential set applies at a time.
+
+### API (jsonData / secureJsonData)
+
+```json
+{
+  "jsonData": {
+    "securityProtocol": "SASL_SSL",
+    "saslMechanisms": "OAUTHBEARER",
+    "saslOauthTokenEndpoint": "https://idp.example.com/oauth2/token",
+    "saslOauthClientId": "my-client-id",
+    "saslOauthScope": "kafka"
+  },
+  "secureJsonData": {
+    "saslOauthClientSecret": "my-client-secret"
+  }
+}
+```
+
+`saslOauthClientSecret` is the only OAuth field treated as a secret; it is stored the
+same way as `saslPassword` and other encrypted datasource fields.
+
+## Behavior
+
+### Token fetch and caching
+
+- On the first connection, and whenever the cached token has expired, the plugin POSTs
+  `grant_type=client_credentials` (plus `client_id`, `client_secret`, and `scope` if set)
+  to the token endpoint as `application/x-www-form-urlencoded`, and expects a JSON
+  response containing `access_token` and `expires_in` (seconds).
+- The token is cached and reused across connections until shortly before it expires —
+  refreshed at `expires_in` minus a skew of `min(30s, 20% of expires_in)` (at least 1
+  second), so a typical 600s token refreshes around the 570s mark.
+- Token fetches are safe for concurrent use: multiple partition-reader connections
+  sharing a mechanism instance will not issue redundant token requests while a valid
+  cached token exists.
+- There is no internal retry on a failed token fetch; retries happen naturally through
+  the existing health check polling and the Kafka reader's own reconnect behavior.
+
+### Error surfacing
+
+Token-fetch failures are wrapped as `failed to fetch OAuth token: <cause>` (for example,
+an unreachable token endpoint, a non-200 response, or a malformed/missing
+`access_token`/`expires_in` in the response), so they are distinguishable from generic
+Kafka connection errors in the **Save & Test** / health check result.
+
+## Limitations
+
+- **No PDC tunneling for the token endpoint.** If your OAuth token endpoint is only
+  reachable through the same private network as your Kafka brokers (i.e. it would need
+  to go through Grafana's Private Data Source Connect tunnel), that is not supported yet
+  — the token-fetch HTTP client dials directly, independent of the PDC dialer used for
+  broker connections.
+- **No live end-to-end broker test in this repo's local dev/e2e stack.** The bundled
+  Docker Compose Kafka broker does not have an OAUTHBEARER listener configured (Kafka's
+  default OAUTHBEARER callback handler only validates unsecured, self-signed JWTs, not a
+  real OIDC exchange), so Playwright e2e coverage is limited to verifying the
+  configuration UI. The token-fetch, caching, refresh, and wire-protocol logic is
+  covered by Go unit tests instead (see below).
+
+## Testing
+
+Unit tests (no live broker required):
+
+- `pkg/kafka_client/oauth_mechanism_test.go`: wire-format (`Start()`'s GS2 initial
+  response), cache-hit behavior, refresh-after-expiry, concurrent-fetch de-duplication,
+  and token endpoint error handling — using `httptest.NewServer` to fake the OIDC token
+  endpoint.
+- `pkg/kafka_client/client_test.go`: `getSASLMechanism` OAUTHBEARER selection, connection
+  validation (missing token endpoint/client id/secret), and composition with TLS and the
+  Grafana PDC dial function.
+
+Run tests:
+
+```bash
+go test ./pkg/kafka_client/... -run OAuth -v
+go test ./pkg/kafka_client/... -run TestNewConnection_OAuthBearer -v
+```
+
+Frontend unit tests (`src/__tests__/ConfigEditor.test.tsx`) cover conditional rendering
+of the OAuth fields and the client secret change/reset flow.
+
+Playwright e2e (`tests/configEditor.spec.ts`, "should allow configuring datasource with
+SASL_SSL and OAUTHBEARER") verifies the fields render, accept input, and persist across a
+save — it does not exercise a live handshake, per the limitation above.
+
+## Related Files
+
+- `pkg/kafka_client/oauth_mechanism.go` - OAUTHBEARER mechanism implementation
+- `pkg/kafka_client/oauth_mechanism_test.go` - Unit tests
+- `pkg/kafka_client/client.go` - `Options`/`KafkaClient` fields, `getSASLMechanism`, `NewConnection`
+- `pkg/plugin/plugin.go` - `getDatasourceSettings` secure field wiring
+- `src/types.ts` - Frontend types
+- `src/ConfigEditor.tsx` - UI components
+- `tests/configEditor.spec.ts` - Playwright e2e smoke test

--- a/docs/OAUTH2_AUTH.md
+++ b/docs/OAUTH2_AUTH.md
@@ -12,7 +12,9 @@ setup.
 
 This is generic OIDC client-credentials support and works with Keycloak, Okta, Azure AD,
 Ping, and any other OIDC-compliant identity provider that implements the
-`client_credentials` grant.
+`client_credentials` grant using the `client_secret_post` client authentication method
+(credentials sent in the POST body). Providers that require `client_secret_basic` (HTTP
+Basic auth) or a client assertion (e.g. private_key_jwt) are not currently supported.
 
 `segmentio/kafka-go` (the Kafka client library this plugin uses) does not implement
 OAUTHBEARER itself — only PLAIN and SCRAM-SHA-256/512 — so this mechanism is implemented
@@ -29,7 +31,9 @@ In the datasource's **Authentication** section:
    recommended, since credentials and tokens should not be sent over plaintext).
 2. Set **SASL Mechanism** to `OAUTHBEARER`.
 3. Fill in:
-   - **Token Endpoint**: your identity provider's OAuth 2.0 token URL.
+   - **Token Endpoint**: your identity provider's OAuth 2.0 token URL. Must be `https://`
+     (plaintext `http://` is only permitted for `localhost`/loopback addresses, to support
+     local testing).
    - **Client ID**: the OAuth client identifier (not secret).
    - **Client Secret**: the OAuth client secret (stored encrypted).
    - **Scope** (optional): a space-delimited scope string requested from the token
@@ -75,6 +79,16 @@ same way as `saslPassword` and other encrypted datasource fields.
 - There is no internal retry on a failed token fetch; retries happen naturally through
   the existing health check polling and the Kafka reader's own reconnect behavior.
 
+### Token endpoint security
+
+- The token endpoint must be `https://`; plaintext `http://` is rejected unless the host
+  is `localhost` or a loopback address (this exception exists solely so local/dev token
+  servers work — real deployments should always use HTTPS).
+- The token-fetch HTTP client does not follow redirects, so a token endpoint cannot
+  forward the client secret to a different host or scheme via a 3xx response.
+- The token endpoint's response body is capped at 1MB; larger responses are rejected
+  before being parsed.
+
 ### Error surfacing
 
 Token-fetch failures are wrapped as `failed to fetch OAuth token: <cause>` (for example,
@@ -102,8 +116,8 @@ Unit tests (no live broker required):
 
 - `pkg/kafka_client/oauth_mechanism_test.go`: wire-format (`Start()`'s GS2 initial
   response), cache-hit behavior, refresh-after-expiry, concurrent-fetch de-duplication,
-  and token endpoint error handling — using `httptest.NewServer` to fake the OIDC token
-  endpoint.
+  token endpoint error handling, HTTPS/loopback enforcement, redirect rejection, and the
+  response size cap — using `httptest.NewServer` to fake the OIDC token endpoint.
 - `pkg/kafka_client/client_test.go`: `getSASLMechanism` OAUTHBEARER selection, connection
   validation (missing token endpoint/client id/secret), and composition with TLS and the
   Grafana PDC dial function.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@babel/core": "7.29.7",
     "@grafana/eslint-config": "10.0.0",
-    "@grafana/plugin-e2e": "3.9.1",
+    "@grafana/plugin-e2e": "3.11.1",
     "@grafana/tsconfig": "2.0.1",
     "@playwright/test": "1.58.2",
     "@stylistic/eslint-plugin": "5.10.0",

--- a/pkg/kafka_client/client.go
+++ b/pkg/kafka_client/client.go
@@ -49,6 +49,11 @@ type Options struct {
 	SaslMechanisms         string `json:"saslMechanisms"`
 	SaslUsername           string `json:"saslUsername"`
 	SaslPassword           string `json:"saslPassword"`
+	// OAUTHBEARER (KIP-255) Configuration
+	SaslOauthTokenEndpoint string `json:"saslOauthTokenEndpoint"`
+	SaslOauthClientId      string `json:"saslOauthClientId"`
+	SaslOauthClientSecret  string `json:"saslOauthClientSecret"`
+	SaslOauthScope         string `json:"saslOauthScope"`
 	EnableSecureSocksProxy bool   `json:"enableSecureSocksProxy"`
 	LogLevel               string `json:"logLevel"`
 	// TLS Configuration
@@ -85,7 +90,12 @@ type KafkaClient struct {
 	SaslMechanisms   string
 	SaslUsername     string
 	SaslPassword     string
-	LogLevel         string
+	// OAUTHBEARER (KIP-255) Configuration
+	SaslOauthTokenEndpoint string
+	SaslOauthClientId      string
+	SaslOauthClientSecret  string
+	SaslOauthScope         string
+	LogLevel               string
 	// TLS Configuration
 	TLSAuthWithCACert bool
 	TLSAuth           bool
@@ -282,6 +292,10 @@ func newKafkaClient(options Options, dialFunc DialFunc) KafkaClient {
 		SaslMechanisms:         options.SaslMechanisms,
 		SaslUsername:           options.SaslUsername,
 		SaslPassword:           options.SaslPassword,
+		SaslOauthTokenEndpoint: options.SaslOauthTokenEndpoint,
+		SaslOauthClientId:      options.SaslOauthClientId,
+		SaslOauthClientSecret:  options.SaslOauthClientSecret,
+		SaslOauthScope:         options.SaslOauthScope,
 		DialFunc:               dialFunc,
 		LogLevel:               options.LogLevel,
 		TLSAuthWithCACert:      options.TLSAuthWithCACert,
@@ -307,8 +321,16 @@ func (client *KafkaClient) NewConnection() error {
 	// Check if SASL is enabled based on security protocol
 	isSASL := client.SecurityProtocol == "SASL_PLAINTEXT" || client.SecurityProtocol == "SASL_SSL"
 	if isSASL {
-		// Validate SASL credentials are provided
-		if client.SaslUsername == "" || client.SaslPassword == "" {
+		mech := client.SaslMechanisms
+		if mech == "" {
+			mech = "PLAIN"
+		}
+		// Validate SASL credentials are provided for the selected mechanism
+		if mech == "OAUTHBEARER" {
+			if client.SaslOauthTokenEndpoint == "" || client.SaslOauthClientId == "" || client.SaslOauthClientSecret == "" {
+				return fmt.Errorf("OAUTHBEARER authentication requires token endpoint, client ID, and client secret")
+			}
+		} else if client.SaslUsername == "" || client.SaslPassword == "" {
 			return fmt.Errorf("SASL authentication requires both username and password")
 		}
 		mechanism, err = getSASLMechanism(client)
@@ -639,6 +661,8 @@ func getSASLMechanism(client *KafkaClient) (sasl.Mechanism, error) {
 		return scram.Mechanism(scram.SHA256, client.SaslUsername, client.SaslPassword)
 	case "SCRAM-SHA-512":
 		return scram.Mechanism(scram.SHA512, client.SaslUsername, client.SaslPassword)
+	case "OAUTHBEARER":
+		return newOAuthBearerMechanism(client), nil
 	default:
 		return nil, fmt.Errorf("unsupported SASL mechanism: %s", mechanism)
 	}

--- a/pkg/kafka_client/client_test.go
+++ b/pkg/kafka_client/client_test.go
@@ -138,6 +138,75 @@ func TestKafkaClient_NewConnection_CustomDialFuncPreservesSASLAndTLS(t *testing.
 	}
 }
 
+func TestKafkaClient_NewConnection_CustomDialFuncPreservesOAuthBearerAndTLS(t *testing.T) {
+	client := NewKafkaClientWithDialFunc(Options{
+		BootstrapServers:       "broker:9092",
+		SecurityProtocol:       "SASL_SSL",
+		SaslMechanisms:         "OAUTHBEARER",
+		SaslOauthTokenEndpoint: "https://idp.example.com/token",
+		SaslOauthClientId:      "client-id",
+		SaslOauthClientSecret:  "client-secret",
+		TLSSkipVerify:          true,
+	}, func(context.Context, string, string) (net.Conn, error) {
+		return nil, errors.New("dial test")
+	})
+
+	if err := client.NewConnection(); err != nil {
+		t.Fatalf("NewConnection() error = %v", err)
+	}
+
+	if client.Dialer.DialFunc == nil || client.Transport.Dial == nil {
+		t.Fatal("expected custom dial function on both Kafka connection paths")
+	}
+	if client.Dialer.SASLMechanism == nil || client.Transport.SASL == nil {
+		t.Fatal("expected SASL configuration to be preserved")
+	}
+	if client.Dialer.SASLMechanism.Name() != "OAUTHBEARER" {
+		t.Fatalf("expected OAUTHBEARER mechanism, got %s", client.Dialer.SASLMechanism.Name())
+	}
+	if client.Dialer.TLS == nil || client.Transport.TLS == nil || !client.Dialer.TLS.InsecureSkipVerify {
+		t.Fatal("expected TLS configuration to be preserved")
+	}
+}
+
+func TestNewConnection_OAuthBearer_RequiresTokenEndpointAndClientCredentials(t *testing.T) {
+	tests := []struct {
+		name    string
+		options Options
+	}{
+		{"missing token endpoint", Options{SecurityProtocol: "SASL_SSL", SaslMechanisms: "OAUTHBEARER", SaslOauthClientId: "id", SaslOauthClientSecret: "secret"}},
+		{"missing client id", Options{SecurityProtocol: "SASL_SSL", SaslMechanisms: "OAUTHBEARER", SaslOauthTokenEndpoint: "https://idp.example.com/token", SaslOauthClientSecret: "secret"}},
+		{"missing client secret", Options{SecurityProtocol: "SASL_SSL", SaslMechanisms: "OAUTHBEARER", SaslOauthTokenEndpoint: "https://idp.example.com/token", SaslOauthClientId: "id"}},
+		{"nothing set", Options{SecurityProtocol: "SASL_SSL", SaslMechanisms: "OAUTHBEARER"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.options.BootstrapServers = "localhost:9092"
+			client := NewKafkaClient(tt.options)
+			if err := client.NewConnection(); err == nil {
+				t.Error("expected error for incomplete OAUTHBEARER configuration, got none")
+			}
+		})
+	}
+}
+
+func TestNewConnection_OAuthBearer_ValidConfiguration(t *testing.T) {
+	client := NewKafkaClient(Options{
+		BootstrapServers:       "localhost:9092",
+		SecurityProtocol:       "SASL_SSL",
+		SaslMechanisms:         "OAUTHBEARER",
+		SaslOauthTokenEndpoint: "https://idp.example.com/token",
+		SaslOauthClientId:      "client-id",
+		SaslOauthClientSecret:  "client-secret",
+	})
+	if err := client.NewConnection(); err != nil {
+		t.Fatalf("NewConnection() error = %v", err)
+	}
+	if client.Dialer.SASLMechanism == nil || client.Dialer.SASLMechanism.Name() != "OAUTHBEARER" {
+		t.Fatal("expected OAUTHBEARER mechanism to be configured")
+	}
+}
+
 func TestKafkaClient_Dispose(t *testing.T) {
 	client := NewKafkaClient(Options{BootstrapServers: "localhost:9092"})
 	client.Dispose() // Should not panic
@@ -159,6 +228,7 @@ func TestGetSASLMechanism_Supported(t *testing.T) {
 		{"PLAIN", "PLAIN"},
 		{"SCRAM-SHA-256", "SCRAM-SHA-256"},
 		{"SCRAM-SHA-512", "SCRAM-SHA-512"},
+		{"OAUTHBEARER", "OAUTHBEARER"},
 		{"", "PLAIN"},
 	}
 	for _, c := range cases {

--- a/pkg/kafka_client/oauth_mechanism.go
+++ b/pkg/kafka_client/oauth_mechanism.go
@@ -1,0 +1,159 @@
+package kafka_client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/segmentio/kafka-go/sasl"
+)
+
+// maxRefreshSkew caps how early a token is proactively refreshed before its
+// reported expiry, so short-lived tokens (e.g. 600s per KIP-255 IdPs) don't
+// refresh needlessly early.
+const maxRefreshSkew = 30 * time.Second
+
+// refreshSkewFraction is the fraction of a token's TTL reserved as refresh
+// skew when the TTL is shorter than 2*maxRefreshSkew.
+const refreshSkewFraction = 0.2
+
+// oauthBearerMechanism implements the SASL/OAUTHBEARER (KIP-255, RFC 7628)
+// mechanism using an OAuth2 client_credentials grant. kafka-go v0.4.47 does
+// not ship this mechanism (only PLAIN and SCRAM-SHA-256/512 exist), so it is
+// implemented here directly against kafka-go's sasl.Mechanism interface.
+//
+// A single instance is constructed per KafkaClient connection and reused
+// across every dial (kafka-go calls Start once per new TCP connection), so
+// the fetched token is cached and proactively refreshed rather than fetched
+// on every connection attempt. Per sasl.Mechanism's contract, instances must
+// be safe for concurrent use by multiple goroutines.
+type oauthBearerMechanism struct {
+	tokenEndpoint string
+	clientID      string
+	clientSecret  string
+	scope         string
+	httpClient    *http.Client
+	nowFunc       func() time.Time
+
+	mu        sync.Mutex
+	token     string
+	expiresAt time.Time
+}
+
+func newOAuthBearerMechanism(client *KafkaClient) *oauthBearerMechanism {
+	timeout := dialerTimeout
+	if client.Timeout > 0 {
+		timeout = time.Duration(client.Timeout) * time.Millisecond
+	}
+	return &oauthBearerMechanism{
+		tokenEndpoint: client.SaslOauthTokenEndpoint,
+		clientID:      client.SaslOauthClientId,
+		clientSecret:  client.SaslOauthClientSecret,
+		scope:         client.SaslOauthScope,
+		httpClient:    &http.Client{Timeout: timeout},
+		nowFunc:       time.Now,
+	}
+}
+
+func (m *oauthBearerMechanism) Name() string {
+	return "OAUTHBEARER"
+}
+
+// Start fetches (or reuses a cached) bearer token and builds the initial
+// GS2 response per RFC 7628: "n,,\x01auth=Bearer <token>\x01\x01".
+func (m *oauthBearerMechanism) Start(ctx context.Context) (sasl.StateMachine, []byte, error) {
+	token, err := m.getToken(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch OAuth token: %w", err)
+	}
+	msg := []byte(fmt.Sprintf("n,,\x01auth=Bearer %s\x01\x01", token))
+	return m, msg, nil
+}
+
+// Next is a formality: kafka-go's SaslAuthenticate round trip already turns a
+// non-zero broker error code into an error before Next is ever invoked, so a
+// successful OAUTHBEARER exchange always calls Next exactly once with an
+// empty challenge (mirroring sasl/plain.Mechanism.Next in this same
+// kafka-go version).
+func (m *oauthBearerMechanism) Next(ctx context.Context, challenge []byte) (bool, []byte, error) {
+	return true, nil, nil
+}
+
+type oauthTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int64  `json:"expires_in"`
+}
+
+func (m *oauthBearerMechanism) getToken(ctx context.Context) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.token != "" && m.nowFunc().Before(m.expiresAt) {
+		return m.token, nil
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", m.clientID)
+	form.Set("client_secret", m.clientSecret)
+	if m.scope != "" {
+		form.Set("scope", m.scope)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, m.tokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("failed to build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token endpoint request failed: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.DefaultLogger.Error("failed to close OAuth token response body", "error", closeErr)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read token endpoint response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token endpoint returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var tokenResp oauthTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("failed to parse token endpoint response: %w", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("token endpoint response missing access_token")
+	}
+	if tokenResp.ExpiresIn <= 0 {
+		return "", fmt.Errorf("token endpoint response missing or invalid expires_in")
+	}
+
+	ttl := time.Duration(tokenResp.ExpiresIn) * time.Second
+	skew := time.Duration(float64(ttl) * refreshSkewFraction)
+	if skew > maxRefreshSkew {
+		skew = maxRefreshSkew
+	}
+	if skew < time.Second {
+		skew = time.Second
+	}
+
+	m.token = tokenResp.AccessToken
+	m.expiresAt = m.nowFunc().Add(ttl - skew)
+
+	return m.token, nil
+}

--- a/pkg/kafka_client/oauth_mechanism.go
+++ b/pkg/kafka_client/oauth_mechanism.go
@@ -3,8 +3,10 @@ package kafka_client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -23,6 +25,13 @@ const maxRefreshSkew = 30 * time.Second
 // refreshSkewFraction is the fraction of a token's TTL reserved as refresh
 // skew when the TTL is shorter than 2*maxRefreshSkew.
 const refreshSkewFraction = 0.2
+
+// maxTokenResponseBytes bounds how much of the token endpoint's response body
+// is read, so a misbehaving or malicious endpoint can't exhaust memory with an
+// oversized response.
+const maxTokenResponseBytes = 1 << 20 // 1MB
+
+var errRedirectNotAllowed = errors.New("redirects are not followed for OAuth token requests")
 
 // oauthBearerMechanism implements the SASL/OAUTHBEARER (KIP-255, RFC 7628)
 // mechanism using an OAuth2 client_credentials grant. kafka-go v0.4.47 does
@@ -57,9 +66,33 @@ func newOAuthBearerMechanism(client *KafkaClient) *oauthBearerMechanism {
 		clientID:      client.SaslOauthClientId,
 		clientSecret:  client.SaslOauthClientSecret,
 		scope:         client.SaslOauthScope,
-		httpClient:    &http.Client{Timeout: timeout},
+		httpClient:    &http.Client{Timeout: timeout, CheckRedirect: rejectRedirects},
 		nowFunc:       time.Now,
 	}
+}
+
+func rejectRedirects(req *http.Request, via []*http.Request) error {
+	return errRedirectNotAllowed
+}
+
+// validateTokenEndpoint requires HTTPS for the token endpoint, since the
+// request carries the client secret in its body. Plaintext HTTP is allowed
+// only against loopback addresses, so local/test token servers (e.g.
+// httptest.NewServer) keep working without weakening the real-world
+// requirement.
+func validateTokenEndpoint(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid token endpoint URL: %w", err)
+	}
+	if u.Scheme == "https" {
+		return nil
+	}
+	host := u.Hostname()
+	if host == "localhost" || net.ParseIP(host).IsLoopback() {
+		return nil
+	}
+	return fmt.Errorf("token endpoint must use https (got %q); plaintext http is only allowed for localhost", rawURL)
 }
 
 func (m *oauthBearerMechanism) Name() string {
@@ -99,6 +132,10 @@ func (m *oauthBearerMechanism) getToken(ctx context.Context) (string, error) {
 		return m.token, nil
 	}
 
+	if err := validateTokenEndpoint(m.tokenEndpoint); err != nil {
+		return "", err
+	}
+
 	form := url.Values{}
 	form.Set("grant_type", "client_credentials")
 	form.Set("client_id", m.clientID)
@@ -123,9 +160,12 @@ func (m *oauthBearerMechanism) getToken(ctx context.Context) (string, error) {
 		}
 	}()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxTokenResponseBytes+1))
 	if err != nil {
 		return "", fmt.Errorf("failed to read token endpoint response: %w", err)
+	}
+	if len(body) > maxTokenResponseBytes {
+		return "", fmt.Errorf("token endpoint response exceeds maximum size of %d bytes", maxTokenResponseBytes)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/pkg/kafka_client/oauth_mechanism_test.go
+++ b/pkg/kafka_client/oauth_mechanism_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -17,7 +18,7 @@ func newTestOAuthMechanism(tokenEndpoint string) *oauthBearerMechanism {
 		clientID:      "client-id",
 		clientSecret:  "client-secret",
 		scope:         "kafka",
-		httpClient:    &http.Client{Timeout: 5 * time.Second},
+		httpClient:    &http.Client{Timeout: 5 * time.Second, CheckRedirect: rejectRedirects},
 		nowFunc:       time.Now,
 	}
 }
@@ -211,6 +212,61 @@ func TestOAuthBearerMechanism_MissingExpiresIn(t *testing.T) {
 	m := newTestOAuthMechanism(server.URL)
 	if _, _, err := m.Start(context.Background()); err == nil {
 		t.Fatal("expected error for missing expires_in")
+	}
+}
+
+func TestOAuthBearerMechanism_RejectsNonLoopbackHTTP(t *testing.T) {
+	m := newTestOAuthMechanism("http://idp.example.com/token")
+	_, _, err := m.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error for non-HTTPS, non-loopback token endpoint")
+	}
+	if !strings.Contains(err.Error(), "must use https") {
+		t.Fatalf("expected https requirement error, got %v", err)
+	}
+}
+
+func TestOAuthBearerMechanism_AllowsLoopbackHTTP(t *testing.T) {
+	server := httptest.NewServer(tokenHandler("loopback-token", 600))
+	defer server.Close()
+
+	m := newTestOAuthMechanism(server.URL)
+	if _, _, err := m.Start(context.Background()); err != nil {
+		t.Fatalf("expected loopback http token endpoint to be allowed, got error: %v", err)
+	}
+}
+
+func TestOAuthBearerMechanism_RejectsRedirect(t *testing.T) {
+	target := httptest.NewServer(tokenHandler("redirected-token", 600))
+	defer target.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+
+	m := newTestOAuthMechanism(server.URL)
+	_, _, err := m.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error when token endpoint issues a redirect")
+	}
+}
+
+func TestOAuthBearerMechanism_RejectsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		oversized := strings.Repeat("a", maxTokenResponseBytes+1)
+		_, _ = fmt.Fprintf(w, `{"access_token":"%s","expires_in":600}`, oversized)
+	}))
+	defer server.Close()
+
+	m := newTestOAuthMechanism(server.URL)
+	_, _, err := m.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error for oversized token endpoint response")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Fatalf("expected size-limit error, got %v", err)
 	}
 }
 

--- a/pkg/kafka_client/oauth_mechanism_test.go
+++ b/pkg/kafka_client/oauth_mechanism_test.go
@@ -1,0 +1,233 @@
+package kafka_client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newTestOAuthMechanism(tokenEndpoint string) *oauthBearerMechanism {
+	return &oauthBearerMechanism{
+		tokenEndpoint: tokenEndpoint,
+		clientID:      "client-id",
+		clientSecret:  "client-secret",
+		scope:         "kafka",
+		httpClient:    &http.Client{Timeout: 5 * time.Second},
+		nowFunc:       time.Now,
+	}
+}
+
+func tokenHandler(accessToken string, expiresIn int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "expected POST", http.StatusMethodNotAllowed)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if r.PostForm.Get("grant_type") != "client_credentials" {
+			http.Error(w, "expected client_credentials grant", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"access_token":"%s","expires_in":%d}`, accessToken, expiresIn)
+	}
+}
+
+func TestOAuthBearerMechanism_Name(t *testing.T) {
+	m := newTestOAuthMechanism("http://example.com/token")
+	if m.Name() != "OAUTHBEARER" {
+		t.Fatalf("expected Name() to be OAUTHBEARER, got %s", m.Name())
+	}
+}
+
+func TestOAuthBearerMechanism_Start_WireFormat(t *testing.T) {
+	server := httptest.NewServer(tokenHandler("test-token", 600))
+	defer server.Close()
+
+	m := newTestOAuthMechanism(server.URL)
+	sess, ir, err := m.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if sess != m {
+		t.Fatal("expected Start() to return itself as the StateMachine")
+	}
+	expected := "n,,\x01auth=Bearer test-token\x01\x01"
+	if string(ir) != expected {
+		t.Fatalf("expected initial response %q, got %q", expected, string(ir))
+	}
+}
+
+func TestOAuthBearerMechanism_Next_CompletesImmediately(t *testing.T) {
+	m := newTestOAuthMechanism("http://example.com/token")
+	done, resp, err := m.Next(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Next() error = %v", err)
+	}
+	if !done {
+		t.Fatal("expected Next() to report done=true")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response, got %v", resp)
+	}
+}
+
+func TestOAuthBearerMechanism_CachesTokenWithinTTL(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		tokenHandler("cached-token", 600)(w, r)
+	}))
+	defer server.Close()
+
+	m := newTestOAuthMechanism(server.URL)
+
+	for i := 0; i < 3; i++ {
+		if _, _, err := m.Start(context.Background()); err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
+	}
+
+	if got := atomic.LoadInt32(&requestCount); got != 1 {
+		t.Fatalf("expected exactly 1 token request while cache is valid, got %d", got)
+	}
+}
+
+func TestOAuthBearerMechanism_RefreshesAfterExpiry(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		tokenHandler(fmt.Sprintf("token-%d", n), 600)(w, r)
+	}))
+	defer server.Close()
+
+	m := newTestOAuthMechanism(server.URL)
+	baseTime := time.Now()
+	m.nowFunc = func() time.Time { return baseTime }
+
+	if _, ir, err := m.Start(context.Background()); err != nil || string(ir) != "n,,\x01auth=Bearer token-1\x01\x01" {
+		t.Fatalf("expected first token, got ir=%q err=%v", ir, err)
+	}
+
+	// Advance time past the cached expiry (600s TTL - 30s skew = 570s window).
+	m.nowFunc = func() time.Time { return baseTime.Add(600 * time.Second) }
+
+	if _, ir, err := m.Start(context.Background()); err != nil || string(ir) != "n,,\x01auth=Bearer token-2\x01\x01" {
+		t.Fatalf("expected refreshed token, got ir=%q err=%v", ir, err)
+	}
+
+	if got := atomic.LoadInt32(&requestCount); got != 2 {
+		t.Fatalf("expected exactly 2 token requests after expiry, got %d", got)
+	}
+}
+
+func TestOAuthBearerMechanism_ConcurrentStartSingleFetch(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		time.Sleep(10 * time.Millisecond) // widen the race window
+		tokenHandler("concurrent-token", 600)(w, r)
+	}))
+	defer server.Close()
+
+	m := newTestOAuthMechanism(server.URL)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 20)
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, _, err := m.Start(context.Background()); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("unexpected Start() error: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&requestCount); got != 1 {
+		t.Fatalf("expected exactly 1 token request under concurrent access, got %d", got)
+	}
+}
+
+func TestOAuthBearerMechanism_TokenEndpointError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	m := newTestOAuthMechanism(server.URL)
+	_, _, err := m.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error for non-200 token endpoint response")
+	}
+}
+
+func TestOAuthBearerMechanism_MalformedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `not-json`)
+	}))
+	defer server.Close()
+
+	m := newTestOAuthMechanism(server.URL)
+	if _, _, err := m.Start(context.Background()); err == nil {
+		t.Fatal("expected error for malformed token endpoint response")
+	}
+}
+
+func TestOAuthBearerMechanism_MissingAccessToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"expires_in":600}`)
+	}))
+	defer server.Close()
+
+	m := newTestOAuthMechanism(server.URL)
+	if _, _, err := m.Start(context.Background()); err == nil {
+		t.Fatal("expected error for missing access_token")
+	}
+}
+
+func TestOAuthBearerMechanism_MissingExpiresIn(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"access_token":"token"}`)
+	}))
+	defer server.Close()
+
+	m := newTestOAuthMechanism(server.URL)
+	if _, _, err := m.Start(context.Background()); err == nil {
+		t.Fatal("expected error for missing expires_in")
+	}
+}
+
+func TestNewOAuthBearerMechanism_UsesClientTimeout(t *testing.T) {
+	client := NewKafkaClient(Options{
+		BootstrapServers:       "localhost:9092",
+		SaslOauthTokenEndpoint: "https://idp.example.com/token",
+		SaslOauthClientId:      "id",
+		SaslOauthClientSecret:  "secret",
+		SaslOauthScope:         "kafka",
+		Timeout:                5000,
+	})
+	m := newOAuthBearerMechanism(&client)
+	if m.httpClient.Timeout != 5*time.Second {
+		t.Fatalf("expected http client timeout to derive from client.Timeout, got %v", m.httpClient.Timeout)
+	}
+	if m.tokenEndpoint != "https://idp.example.com/token" || m.clientID != "id" || m.clientSecret != "secret" || m.scope != "kafka" {
+		t.Fatal("expected OAuth fields to be copied from the client")
+	}
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -95,6 +95,11 @@ func getDatasourceSettings(s backend.DataSourceInstanceSettings) (*kafka_client.
 		settings.SaslPassword = saslPassword
 	}
 
+	// OAUTHBEARER (KIP-255) client secret from secure JSON data
+	if saslOauthClientSecret, exists := s.DecryptedSecureJSONData["saslOauthClientSecret"]; exists {
+		settings.SaslOauthClientSecret = saslOauthClientSecret
+	}
+
 	// TLS certificate fields from secure JSON data
 	if caCert, exists := s.DecryptedSecureJSONData["tlsCACert"]; exists {
 		settings.TLSCACert = caCert

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,8 +56,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0(@stylistic/eslint-plugin@5.10.0(eslint@9.39.2))(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(@typescript-eslint/parser@8.63.0(eslint@9.39.2)(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint-plugin-jsdoc@63.0.13(eslint@9.39.2))(eslint-plugin-react-hooks@7.1.1(eslint@9.39.2))(eslint-plugin-react@7.37.5(eslint@9.39.2))(eslint@9.39.2)(typescript@5.9.3)
       '@grafana/plugin-e2e':
-        specifier: 3.9.1
-        version: 3.9.1(@playwright/test@1.58.2)
+        specifier: 3.11.1
+        version: 3.11.1(@playwright/test@1.58.2)
       '@grafana/tsconfig':
         specifier: 2.0.1
         version: 2.0.1
@@ -724,9 +724,9 @@ packages:
     resolution:
       { integrity: sha512-g/N5gGZ4iE59g4Coi/R6+F66BRrBnP0XKa7DO7sbiGo4IgM2tGsXgVvWNcR4CCF7bza930mhVWQnREyNLhClFw== }
 
-  '@grafana/e2e-selectors@13.1.0-25644485979':
+  '@grafana/e2e-selectors@13.2.0-30594044109':
     resolution:
-      { integrity: sha512-2H+veZBayawey47iUTb5N69QK5KYHxzspe8uaauvLH7aSsjeyzH6nFubLkOVxz1JUOVtVrwOaH+libUwSaPMXw== }
+      { integrity: sha512-CRN0CTsSkAC3qQvufbR7duUzSX2Jfgc/g5ap+eSrjcFcS+vAVUDGfQVLK6y5ojN+B0gATNIbmVlCGngQxmm+eA== }
 
   '@grafana/eslint-config@10.0.0':
     resolution:
@@ -756,9 +756,9 @@ packages:
     peerDependencies:
       react: '>=18'
 
-  '@grafana/plugin-e2e@3.9.1':
+  '@grafana/plugin-e2e@3.11.1':
     resolution:
-      { integrity: sha512-LqRDbTaIK/1IEJFEp+KPdqkLpLuvPgoaNiUCKEJscQIW6vH+eK2PKvaL7L+U7Lf4Xk6Gk85zTkivPge9/LBKaw== }
+      { integrity: sha512-FYRGH2HXvlz8tP1QD2feEmK4vEx5np5nRYogNg3L3E+UMMdY1u2IlGWIjEKnQvIg2TFRl4tCgEF97+NaElSpgg== }
     engines: { node: '>=20 <=24' }
     peerDependencies:
       '@axe-core/playwright': ^4.11.1
@@ -7092,11 +7092,9 @@ snapshots:
       semver: 7.7.4
       typescript: 6.0.2
 
-  '@grafana/e2e-selectors@13.1.0-25644485979':
+  '@grafana/e2e-selectors@13.2.0-30594044109':
     dependencies:
       semver: 7.7.4
-      tslib: 2.8.1
-      typescript: 6.0.2
 
   '@grafana/eslint-config@10.0.0(@stylistic/eslint-plugin@5.10.0(eslint@9.39.2))(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(@typescript-eslint/parser@8.63.0(eslint@9.39.2)(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint-plugin-jsdoc@63.0.13(eslint@9.39.2))(eslint-plugin-react-hooks@7.1.1(eslint@9.39.2))(eslint-plugin-react@7.37.5(eslint@9.39.2))(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
@@ -7139,9 +7137,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@grafana/plugin-e2e@3.9.1(@playwright/test@1.58.2)':
+  '@grafana/plugin-e2e@3.11.1(@playwright/test@1.58.2)':
     dependencies:
-      '@grafana/e2e-selectors': 13.1.0-25644485979
+      '@grafana/e2e-selectors': 13.2.0-30594044109
       '@playwright/test': 1.58.2
       yaml: 2.9.0
 

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -32,6 +32,7 @@ const SASL_MECHANISM_OPTIONS = [
   { label: 'PLAIN', value: 'PLAIN', description: 'Simple username/password authentication' },
   { label: 'SCRAM-SHA-256', value: 'SCRAM-SHA-256', description: 'SCRAM with SHA-256' },
   { label: 'SCRAM-SHA-512', value: 'SCRAM-SHA-512', description: 'SCRAM with SHA-512' },
+  { label: 'OAUTHBEARER', value: 'OAUTHBEARER', description: 'OAuth 2.0 client credentials (KIP-255)' },
 ];
 
 const getStyles = (theme: GrafanaTheme2) => {
@@ -99,6 +100,36 @@ export const ConfigEditor = (props: Props) => {
       ...options,
       secureJsonFields: { ...options.secureJsonFields, saslPassword: false },
       secureJsonData: { ...options.secureJsonData, saslPassword: '' },
+    });
+  };
+
+  const onSaslOauthTokenEndpointChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onOptionsChange({
+      ...options,
+      jsonData: { ...options.jsonData, saslOauthTokenEndpoint: event.target.value },
+    });
+  };
+
+  const onSaslOauthClientIdChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onOptionsChange({ ...options, jsonData: { ...options.jsonData, saslOauthClientId: event.target.value } });
+  };
+
+  const onSaslOauthScopeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onOptionsChange({ ...options, jsonData: { ...options.jsonData, saslOauthScope: event.target.value } });
+  };
+
+  const onSaslOauthClientSecretChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onOptionsChange({
+      ...options,
+      secureJsonData: { ...options.secureJsonData, saslOauthClientSecret: event.target.value },
+    });
+  };
+
+  const onResetSaslOauthClientSecret = () => {
+    onOptionsChange({
+      ...options,
+      secureJsonFields: { ...options.secureJsonFields, saslOauthClientSecret: false },
+      secureJsonData: { ...options.secureJsonData, saslOauthClientSecret: '' },
     });
   };
 
@@ -315,27 +346,102 @@ export const ConfigEditor = (props: Props) => {
               />
             </InlineField>
 
-            <InlineField label="SASL Username" labelWidth={20} tooltip="SASL username for authentication" grow required>
-              <Input
-                id="config-editor-sasl-username"
-                onChange={onSaslUsernameChange}
-                value={jsonData.saslUsername}
-                placeholder="SASL Username"
-                width={40}
-              />
-            </InlineField>
+            {jsonData.saslMechanisms === 'OAUTHBEARER' ? (
+              <>
+                <InlineField
+                  label="Token Endpoint"
+                  labelWidth={20}
+                  tooltip="OAuth 2.0 token endpoint URL used for the client_credentials grant"
+                  grow
+                  required
+                >
+                  <Input
+                    id="config-editor-oauth-token-endpoint"
+                    data-testid="oauth-token-endpoint"
+                    onChange={onSaslOauthTokenEndpointChange}
+                    value={jsonData.saslOauthTokenEndpoint || ''}
+                    placeholder="https://idp.example.com/oauth2/token"
+                    width={40}
+                  />
+                </InlineField>
 
-            <InlineField label="SASL Password" labelWidth={20} tooltip="SASL password for authentication" grow required>
-              <SecretInput
-                id="config-editor-sasl-password"
-                isConfigured={(secureJsonFields && secureJsonFields.saslPassword) as boolean}
-                value={secureJsonData.saslPassword || ''}
-                placeholder="SASL Password"
-                width={40}
-                onReset={onResetSaslPassword}
-                onChange={onSaslPasswordChange}
-              />
-            </InlineField>
+                <InlineField label="Client ID" labelWidth={20} tooltip="OAuth 2.0 client identifier" grow required>
+                  <Input
+                    id="config-editor-oauth-client-id"
+                    data-testid="oauth-client-id"
+                    onChange={onSaslOauthClientIdChange}
+                    value={jsonData.saslOauthClientId || ''}
+                    placeholder="OAuth Client ID"
+                    width={40}
+                  />
+                </InlineField>
+
+                <InlineField label="Client Secret" labelWidth={20} tooltip="OAuth 2.0 client secret" grow required>
+                  <SecretInput
+                    id="config-editor-oauth-client-secret"
+                    data-testid="oauth-client-secret"
+                    isConfigured={(secureJsonFields && secureJsonFields.saslOauthClientSecret) as boolean}
+                    value={secureJsonData.saslOauthClientSecret || ''}
+                    placeholder="OAuth Client Secret"
+                    width={40}
+                    onReset={onResetSaslOauthClientSecret}
+                    onChange={onSaslOauthClientSecretChange}
+                  />
+                </InlineField>
+
+                <InlineField
+                  label="Scope"
+                  labelWidth={20}
+                  tooltip="OAuth 2.0 scope requested from the token endpoint (optional)"
+                  grow
+                >
+                  <Input
+                    id="config-editor-oauth-scope"
+                    data-testid="oauth-scope"
+                    onChange={onSaslOauthScopeChange}
+                    value={jsonData.saslOauthScope || ''}
+                    placeholder="kafka"
+                    width={40}
+                  />
+                </InlineField>
+              </>
+            ) : (
+              <>
+                <InlineField
+                  label="SASL Username"
+                  labelWidth={20}
+                  tooltip="SASL username for authentication"
+                  grow
+                  required
+                >
+                  <Input
+                    id="config-editor-sasl-username"
+                    onChange={onSaslUsernameChange}
+                    value={jsonData.saslUsername}
+                    placeholder="SASL Username"
+                    width={40}
+                  />
+                </InlineField>
+
+                <InlineField
+                  label="SASL Password"
+                  labelWidth={20}
+                  tooltip="SASL password for authentication"
+                  grow
+                  required
+                >
+                  <SecretInput
+                    id="config-editor-sasl-password"
+                    isConfigured={(secureJsonFields && secureJsonFields.saslPassword) as boolean}
+                    value={secureJsonData.saslPassword || ''}
+                    placeholder="SASL Password"
+                    width={40}
+                    onReset={onResetSaslPassword}
+                    onChange={onSaslPasswordChange}
+                  />
+                </InlineField>
+              </>
+            )}
           </>
         )}
 

--- a/src/__tests__/ConfigEditor.test.tsx
+++ b/src/__tests__/ConfigEditor.test.tsx
@@ -335,6 +335,107 @@ describe('ConfigEditor', () => {
     );
   });
 
+  it('shows OAuth fields and hides username/password when OAUTHBEARER is selected', () => {
+    renderConfigEditor({ securityProtocol: 'SASL_SSL', saslMechanisms: 'OAUTHBEARER' });
+
+    expect(screen.getByPlaceholderText('https://idp.example.com/oauth2/token')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('OAuth Client ID')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('OAuth Client Secret')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('kafka')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('SASL Username')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('SASL Password')).not.toBeInTheDocument();
+  });
+
+  it('hides OAuth fields when a non-OAUTHBEARER mechanism is selected', () => {
+    renderConfigEditor({ securityProtocol: 'SASL_SSL', saslMechanisms: 'PLAIN' });
+
+    expect(screen.queryByPlaceholderText('https://idp.example.com/oauth2/token')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('OAuth Client ID')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('OAuth Client Secret')).not.toBeInTheDocument();
+  });
+
+  it('calls onOptionsChange when OAuth token endpoint changes', () => {
+    renderConfigEditor({ securityProtocol: 'SASL_SSL', saslMechanisms: 'OAUTHBEARER' });
+    const input = screen.getByPlaceholderText('https://idp.example.com/oauth2/token');
+
+    fireEvent.change(input, { target: { value: 'https://idp.example.com/token' } });
+
+    expect(mockOnOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({
+          saslOauthTokenEndpoint: 'https://idp.example.com/token',
+        }),
+      })
+    );
+  });
+
+  it('calls onOptionsChange when OAuth client ID changes', () => {
+    renderConfigEditor({ securityProtocol: 'SASL_SSL', saslMechanisms: 'OAUTHBEARER' });
+    const input = screen.getByPlaceholderText('OAuth Client ID');
+
+    fireEvent.change(input, { target: { value: 'my-client-id' } });
+
+    expect(mockOnOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({
+          saslOauthClientId: 'my-client-id',
+        }),
+      })
+    );
+  });
+
+  it('calls onOptionsChange when OAuth scope changes', () => {
+    renderConfigEditor({ securityProtocol: 'SASL_SSL', saslMechanisms: 'OAUTHBEARER' });
+    const input = screen.getByPlaceholderText('kafka');
+
+    fireEvent.change(input, { target: { value: 'kafka.read' } });
+
+    expect(mockOnOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({
+          saslOauthScope: 'kafka.read',
+        }),
+      })
+    );
+  });
+
+  it('calls onOptionsChange when OAuth client secret changes', () => {
+    renderConfigEditor({ securityProtocol: 'SASL_SSL', saslMechanisms: 'OAUTHBEARER' });
+    const input = screen.getByPlaceholderText('OAuth Client Secret');
+
+    fireEvent.change(input, { target: { value: 'my-secret' } });
+
+    expect(mockOnOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        secureJsonData: expect.objectContaining({
+          saslOauthClientSecret: 'my-secret',
+        }),
+      })
+    );
+  });
+
+  it('handles OAuth client secret reset', () => {
+    renderConfigEditor(
+      { securityProtocol: 'SASL_SSL', saslMechanisms: 'OAUTHBEARER' },
+      { saslOauthClientSecret: 'existing-secret' },
+      { saslOauthClientSecret: true }
+    );
+
+    const resetButton = screen.getByTestId('reset-button');
+    fireEvent.click(resetButton);
+
+    expect(mockOnOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        secureJsonFields: expect.objectContaining({
+          saslOauthClientSecret: false,
+        }),
+        secureJsonData: expect.objectContaining({
+          saslOauthClientSecret: '',
+        }),
+      })
+    );
+  });
+
   it('calls onOptionsChange when TLS skip verify changes', () => {
     renderConfigEditor({ securityProtocol: 'SSL' });
     const checkbox = screen.getAllByTestId('checkbox')[1]; // PDC checkbox is first
@@ -707,5 +808,21 @@ describe('ConfigEditor', () => {
     expect(screen.getByDisplayValue('10000')).toBeInTheDocument();
     expect(screen.getByDisplayValue('8')).toBeInTheDocument();
     expect(screen.getByDisplayValue('1500')).toBeInTheDocument();
+  });
+
+  it('preserves existing OAUTHBEARER configuration values', () => {
+    const existingConfig = {
+      securityProtocol: 'SASL_SSL',
+      saslMechanisms: 'OAUTHBEARER',
+      saslOauthTokenEndpoint: 'https://idp.example.com/token',
+      saslOauthClientId: 'existing-client-id',
+      saslOauthScope: 'kafka.read',
+    };
+
+    renderConfigEditor(existingConfig);
+
+    expect(screen.getByDisplayValue('https://idp.example.com/token')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('existing-client-id')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('kafka.read')).toBeInTheDocument();
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,10 @@ export interface KafkaDataSourceOptions extends DataSourceJsonData {
   securityProtocol: string;
   saslMechanisms: string;
   saslUsername: string;
+  // OAUTHBEARER (KIP-255) Configuration
+  saslOauthTokenEndpoint?: string;
+  saslOauthClientId?: string;
+  saslOauthScope?: string;
   logLevel: string;
   healthcheckTimeout: number;
   // TLS Configuration
@@ -93,6 +97,9 @@ export const defaultDataSourceOptions: Partial<KafkaDataSourceOptions> = {
   securityProtocol: 'PLAINTEXT',
   saslMechanisms: '',
   saslUsername: '',
+  saslOauthTokenEndpoint: '',
+  saslOauthClientId: '',
+  saslOauthScope: '',
   logLevel: '',
   healthcheckTimeout: 2000,
   tlsAuthWithCACert: false,
@@ -107,6 +114,7 @@ export const defaultDataSourceOptions: Partial<KafkaDataSourceOptions> = {
 export interface KafkaSecureJsonData {
   apiKey?: string; // Deprecated
   saslPassword?: string;
+  saslOauthClientSecret?: string;
   // TLS Certificates
   tlsCACert?: string;
   tlsClientCert?: string;

--- a/tests/configEditor.spec.ts
+++ b/tests/configEditor.spec.ts
@@ -399,6 +399,53 @@ test.describe('Kafka Config Editor', () => {
     await expect(configPage.saveAndTest()).toBeOK();
   });
 
+  test('should allow configuring datasource with SASL_SSL and OAUTHBEARER', async ({
+    createDataSourceConfigPage,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasource.yaml' });
+    const configPage = await createDataSourceConfigPage({ type: ds.type });
+
+    // NOTE: this test only verifies that the OAUTHBEARER config fields render,
+    // accept input, and persist across a save. It does not exercise a live
+    // SASL/OAUTHBEARER handshake against a real broker, because the local
+    // docker-compose Kafka stack has no OAUTHBEARER/OIDC listener configured
+    // (Kafka's default OAUTHBEARER callback handler only validates unsecured
+    // self-signed JWTs, not a real client_credentials exchange). Wire-protocol
+    // level coverage (token fetch, caching, refresh) lives in
+    // pkg/kafka_client/oauth_mechanism_test.go.
+    await page.getByRole('textbox', { name: 'Bootstrap Servers' }).fill('kafka:39092');
+
+    await page
+      .locator('div')
+      .filter({ hasText: /^PLAINTEXT$/ })
+      .nth(2)
+      .click();
+    await page.getByText('SASL_SSL', { exact: true }).click();
+    await page.waitForTimeout(500);
+
+    await page
+      .locator('div')
+      .filter({ hasText: /^PLAIN$/ })
+      .nth(2)
+      .click();
+    await page.getByText('OAUTHBEARER', { exact: true }).click();
+
+    await page.getByTestId('oauth-token-endpoint').fill('https://idp.example.com/oauth2/token');
+    await page.getByTestId('oauth-client-id').fill('my-oauth-client');
+    await page.getByTestId('oauth-client-secret').fill('my-oauth-secret');
+    await page.getByTestId('oauth-scope').fill('kafka');
+
+    // Save & test the data source - not expected to succeed (see note above).
+    await expect(configPage.saveAndTest()).not.toBeOK();
+
+    // Verify the configuration values are preserved.
+    await expect(page.getByTestId('oauth-token-endpoint')).toHaveValue('https://idp.example.com/oauth2/token');
+    await expect(page.getByTestId('oauth-client-id')).toHaveValue('my-oauth-client');
+    await expect(page.getByTestId('oauth-scope')).toHaveValue('kafka');
+  });
+
   test('should allow configuring Schema Registry for Avro support', async ({
     createDataSourceConfigPage,
     readProvisionedDataSource,


### PR DESCRIPTION
## Summary

- Implements SASL/OAUTHBEARER (KIP-255) authentication using an OAuth 2.0 `client_credentials` grant, since `segmentio/kafka-go` (pinned at v0.4.47) only ships PLAIN and SCRAM-SHA-256/512 — the mechanism is implemented from scratch against kafka-go's `sasl.Mechanism` interface in `pkg/kafka_client/oauth_mechanism.go`, with a mutex-guarded token cache that proactively refreshes before expiry (skew = `min(30s, 20% of TTL)`, clamped to ≥1s).
- Adds a new `OAUTHBEARER` option to the Config Editor's SASL Mechanism dropdown with Token Endpoint / Client ID / Client Secret (encrypted) / Scope fields, following the existing SASL password secure-field pattern.
- Generic to any OIDC-compliant IdP (Keycloak, Okta, Azure AD, Ping, etc.), as discussed in #155.

Closes #155

## Known limitations (documented in `docs/OAUTH2_AUTH.md`)

- The OAuth token-fetch HTTP client does not go through Grafana PDC — only relevant if the token endpoint is reachable exclusively via the same private network as the brokers.
- The local Docker Compose Kafka broker has no OAUTHBEARER/OIDC listener (its default callback handler only validates unsecured self-signed JWTs), so there's no live end-to-end broker test. Wire-protocol/token-cache/refresh behavior is covered by Go unit tests against a fake token endpoint instead.

## Test plan

- [x] `go test -race ./...` — all backend tests pass, including new `pkg/kafka_client/oauth_mechanism_test.go` (wire format, cache hit, refresh-after-expiry, concurrent-fetch de-duplication, error handling) and extended `client_test.go` cases (mechanism selection, connection validation, TLS/PDC composition)
- [x] `golangci-lint run` — clean
- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run test:ci` — all pass, including new `ConfigEditor.test.tsx` cases for the OAuth fields
- [x] `pnpm run lint:md` — clean
- [x] Manually built the plugin (`pnpm run build` + `mage buildAll`) and ran it against the local Docker Compose Grafana+Kafka stack; verified the new OAUTHBEARER Config Editor fields render, accept input, and persist across save via Playwright (`tests/configEditor.spec.ts`, full suite of 14 tests passing, including the new one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OAUTHBEARER authentication for Kafka using OAuth 2.0 client credentials.
  - Added configuration fields for the token endpoint, client ID, client secret, and scope.
  - Added token caching and automatic refresh.
  - Added OAuth settings to the datasource configuration interface.

- **Documentation**
  - Expanded authentication guidance with supported SASL mechanisms.
  - Added OAuth 2.0 setup and security documentation, including HTTPS and provider compatibility requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->